### PR TITLE
More permissive restrictions on Rufus scheduler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
+## 1.0.5
+ - Fixed issue where overly restrictive dependency on rufus scheduler was stopping Logstash from upgrading this plugin. [35](https://github.com/logstash-plugins/logstash-filter-jdbc_static/pull/35)
+
 ## 1.0.4
  - Fixed pipeline reload thread leak by implementing the correct close method to release resources [#34](https://github.com/logstash-plugins/logstash-filter-jdbc_static/pull/34)
  - Fixed error caused by code removed in latest version of Rufus scheduler by pinning dependency [#34](https://github.com/logstash-plugins/logstash-filter-jdbc_static/pull/34)
 
 ## 1.0.3
  - Fix [jdbc_static filter - #25](https://github.com/logstash-plugins/logstash-filter-jdbc_static/issues/25) When index_columns is not specified, the create table statement has a syntax error.
-
 ## 1.0.2
  - Fix [jdbc_static filter - #22](https://github.com/logstash-plugins/logstash-filter-jdbc_static/issues/22) Support multiple driver libraries.
  - Fixes for [jdbc_static filter - #18](https://github.com/logstash-plugins/logstash-filter-jdbc_static/issues/18), [jdbc_static filter - #17](https://github.com/logstash-plugins/logstash-filter-jdbc_static/issues/17), [jdbc_static filter - #12](https://github.com/logstash-plugins/logstash-filter-jdbc_static/issues/12) Use Java classloader to load driver jar. Use system import from file to loader local database. Prevent locking errors when no records returned.

--- a/logstash-filter-jdbc_static.gemspec
+++ b/logstash-filter-jdbc_static.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-filter-jdbc_static'
-  s.version         = '1.0.4'
+  s.version         = '1.0.5'
   s.licenses        = ['Apache-2.0']
   s.summary         = "This filter executes a SQL query to fetch a SQL query result, store it locally then use a second SQL query to update an event."
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/logstash-filter-jdbc_static.gemspec
+++ b/logstash-filter-jdbc_static.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'sequel'
   s.add_runtime_dependency 'tzinfo'
   s.add_runtime_dependency 'tzinfo-data'
-  s.add_runtime_dependency 'rufus-scheduler', '~> 3.4.0'
+  s.add_runtime_dependency 'rufus-scheduler', '< 3.5'
 
   s.add_development_dependency 'logstash-devutils'
   s.add_development_dependency 'timecop'


### PR DESCRIPTION
To allow previous versions of Logstash to be able to upgrade to this
  plugin, while still avoiding newer incompatible versions.