### PR TITLE
Fix Integration Tests

### DIFF
--- a/ci/unit/docker-compose.yml
+++ b/ci/unit/docker-compose.yml
@@ -15,10 +15,14 @@ services:
       LS_JAVA_OPTS: "-Xmx256m -Xms256m"
       LOGSTASH_SOURCE: 1
       PG_CONNECTION_STRING: "jdbc:postgresql://postgresql:5432"
+      POSTGRES_PASSWORD: "test_user_password"
+
     tty: true
 
   postgresql:
     image: postgres:latest
+    environment:
+      POSTGRES_PASSWORD: "test_user_password"
     volumes:
     - ./setup.sql:/docker-entrypoint-initdb.d/init.sql
     ports:

--- a/spec/filters/integration/jdbc_static_spec.rb
+++ b/spec/filters/integration/jdbc_static_spec.rb
@@ -35,6 +35,7 @@ module LogStash module Filters
     let(:settings) do
       {
         "jdbc_user" => ENV['USER'],
+        "jdbc_password" => ENV['POSTGRES_PASSWORD'],
         "jdbc_driver_class" => "org.postgresql.Driver",
         "jdbc_driver_library" => "/usr/share/logstash/postgresql.jar",
         "staging_directory" => temp_import_path_plugin,
@@ -88,6 +89,7 @@ module LogStash module Filters
         let(:settings) do
           {
             "jdbc_user" => ENV['USER'],
+            "jdbc_password" => ENV['POSTGRES_PASSWORD'],
             "jdbc_driver_class" => "org.postgresql.Driver",
             "jdbc_driver_library" => "/usr/share/logstash/postgresql.jar",
             "staging_directory" => temp_import_path_plugin,


### PR DESCRIPTION
Integration tests were failing due to a behavioural change in a
patch release of the postgres docker image, which now requires
a password to be set, or an explicit ENV setting to not require this.
